### PR TITLE
Change to HTTPS to prevent mixed-content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Twitter Bootstrap -->
-        <link href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
 
         <!-- Material Design for Bootstrap -->
         <link href="css/material-wfont.min.css" rel="stylesheet">
@@ -15,10 +15,10 @@
         <link href="css/custom.css" rel="stylesheet">
 
         <!-- Font Awesome -->
-        <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+        <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css">
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/default.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
 
 
         <!-- jQuery -->


### PR DESCRIPTION
When visiting the webpage via https://jillix.github.io/url.js/ it will show a mixed-content warning and will block insecure content. Making those insecure content be loaded thought a secure connection will solve this.