### PR TITLE
Use window.location.pathname in updateSearchParam

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "contributors": [
-    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)"
+    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+    "Andrey Mikhaylov <lolmaus@gmail.com> (http://github.com/lolmaus/)"
   ],
   "repository": {
     "type": "git",

--- a/src/url.js
+++ b/src/url.js
@@ -123,7 +123,7 @@
         }
 
         var newSearch = "?" + stringify(searchParsed);
-        window.history.replaceState(null, "", newSearch + location.hash);
+        window.history.replaceState(null, "", window.location.pathname + newSearch + location.hash);
 
         return Url;
     }


### PR DESCRIPTION
Without this change, `Url.updateSearchParam('foo', 'bar')` turn url `http://localhost:3000/tests` to `http://localhost:3000/?foo=bar` whereas `http://localhost:3000/tests?foo=bar` is expected.

No idea why the bug is not happening on the demo website. But I made sure that after this change the demo website still behaves as expected.